### PR TITLE
Feat: Add entity methos for populate directly and inverse relations

### DIFF
--- a/src/main/java/com/andresoft/optimumbooking/domain/entities/Customer.java
+++ b/src/main/java/com/andresoft/optimumbooking/domain/entities/Customer.java
@@ -42,6 +42,6 @@ public class Customer {
 
     @ToString.Exclude
     @EqualsAndHashCode.Exclude
-    @OneToMany(mappedBy = "customer", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @OneToMany(mappedBy = "customer", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private Set<Tour> tours;
 }

--- a/src/main/java/com/andresoft/optimumbooking/domain/entities/Tour.java
+++ b/src/main/java/com/andresoft/optimumbooking/domain/entities/Tour.java
@@ -3,7 +3,10 @@ package com.andresoft.optimumbooking.domain.entities;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 
 @Entity
 @NoArgsConstructor
@@ -29,4 +32,32 @@ public class Tour {
     @ManyToOne
     @JoinColumn(name = "id_customer", nullable = true)
     private Customer customer;
+
+    public void addReservation(Reservation reservation) {
+        if(Objects.isNull(this.reservations)) this.reservations = new HashSet<>();
+        this.reservations.add(reservation);
+    }
+
+    public void removeReservation(UUID id) {
+        if(Objects.isNull(this.reservations)) this.reservations = new HashSet<>();
+        this.reservations.removeIf(reservation -> reservation.getId().equals(id));
+    }
+
+    public void updateReservation() {
+        this.reservations.forEach(reservation -> reservation.setTour(this));
+    }
+
+    public void addTicket(Ticket ticket) {
+        if(Objects.isNull(this.tickets)) this.tickets = new HashSet<>();
+        this.tickets.add(ticket);
+    }
+
+    public void removeTicket(UUID id) {
+        if(Objects.isNull(this.tickets)) this.tickets = new HashSet<>();
+        this.tickets.removeIf(ticket -> ticket.getId().equals(id));
+    }
+
+    public void updateTicket() {
+        this.tickets.forEach(ticket -> ticket.setTour(this));
+    }
 }

--- a/src/main/java/com/andresoft/optimumbooking/domain/repositories/HotelRepository.java
+++ b/src/main/java/com/andresoft/optimumbooking/domain/repositories/HotelRepository.java
@@ -16,5 +16,5 @@ public interface HotelRepository extends JpaRepository<Hotel, Long> {
 
     Set<Hotel> findByRatingGreaterThan(int rating);
 
-    Optional<Hotel> findByReservationId(UUID id);
+    Optional<Hotel> findByReservationsId(UUID id);
 }


### PR DESCRIPTION
# Pull Request: Feature - Add Entity Methods for Populating Relations

## Description

This pull request introduces new methods in the `Tour` entity to facilitate populating direct and inverse relations. Additionally, it includes changes in the `Customer` entity to modify the fetch type from eager to lazy in the relationship with tours.

## Changes Made

### Tour Entity
- Added methods for populating direct and inverse relations:
  - `addReservation()`: This method populates the direct relations of the tour entity.
  - `removeReservation()`: This method removes the inverse relations of the tour entity.
  - `updateReservation()`: This method update the inverse relations of the tour entity.

- Also the same methods were used for Ticket relationship on Tour entity.

### Customer Entity
- Changed the fetch type from eager to lazy in the relationship with tours. This modification aims to improve performance by delaying the loading of tour data until it's explicitly requested.

## Testing

All changes have been thoroughly tested locally to ensure they function as expected. Specifically:
- The new methods in the `Tour` entity have been tested to verify they correctly populate relations.
- The modified fetch type in the `Customer` entity has been tested to ensure it behaves as intended, loading tour data lazily when accessed.

